### PR TITLE
Clone list of listeners for emitting

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -20,7 +20,9 @@ export class Emitter {
   }
   emit(event, ...args) {
     if (typeof this.events[event] === "object") {
-      this.events[event].forEach((listener) => listener.apply(this, args));
+      // duplicate the list first, to avoid issues with 'once'
+      // altering the list
+      [ ...this.events[event]].forEach((listener) => listener.apply(this, args));
     }
   }
   once(event, listener) {


### PR DESCRIPTION
If 'once' is used, then when the event is emitted it will remove itself from the listeners. But the list is still being interated for other listeners.

Clone the list to prevent this occuring